### PR TITLE
Removed usage of EnumChatFormatting

### DIFF
--- a/src/main/java/de/labyhelp/addon/LabyHelp.java
+++ b/src/main/java/de/labyhelp/addon/LabyHelp.java
@@ -38,7 +38,6 @@ import net.labymod.settings.elements.*;
 import net.labymod.utils.Consumer;
 import net.labymod.utils.Material;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.EnumChatFormatting;
 
 import java.util.HashMap;
 import java.util.List;
@@ -680,7 +679,7 @@ public class LabyHelp extends net.labymod.api.LabyModAddon {
                     LabyHelp.getInstance().getExecutor().submit(() -> {
                         getTagManager().sendSpecificTag(false, LabyMod.getInstance().getPlayerUUID(), alignment);
                         getTagManager().initTagManager();
-                        labyPlayer.sendDefaultMessage(EnumChatFormatting.GREEN + LabyHelp.getInstance().getTranslationManager().getTranslation("main.tag.change") + EnumChatFormatting.WHITE + " (" + alignment.getRequestName() + ")");
+                        labyPlayer.sendDefaultMessage("§a" + LabyHelp.getInstance().getTranslationManager().getTranslation("main.tag.change") + "§f" + " (" + alignment.getRequestName() + ")");
                     });
 
                     LabyHelp.this.getConfig().addProperty("leftTag", alignment.name());
@@ -690,7 +689,7 @@ public class LabyHelp extends net.labymod.api.LabyModAddon {
                 }
             } else {
                 if (!getSettingsManager().leftTag.equals(alignment.name())) {
-                    labyPlayer.sendDefaultMessage(EnumChatFormatting.RED + LabyHelp.getInstance().getTranslationManager().getTranslation("main.tag.noperms") + EnumChatFormatting.WHITE + " (" + alignment.getRequestName() + ")");
+                    labyPlayer.sendDefaultMessage("§c" + LabyHelp.getInstance().getTranslationManager().getTranslation("main.tag.noperms") + "§f" + " (" + alignment.getRequestName() + ")");
                 }
             }
 
@@ -722,7 +721,7 @@ public class LabyHelp extends net.labymod.api.LabyModAddon {
                     LabyHelp.getInstance().getExecutor().submit(() -> {
                         getTagManager().sendSpecificTag(true, LabyMod.getInstance().getPlayerUUID(), alignment);
                         getTagManager().initTagManager();
-                        labyPlayer.sendDefaultMessage(EnumChatFormatting.GREEN + LabyHelp.getInstance().getTranslationManager().getTranslation("main.tag.change") + EnumChatFormatting.WHITE + " (" + alignment.getRequestName() + ")");
+                        labyPlayer.sendDefaultMessage("§a" + LabyHelp.getInstance().getTranslationManager().getTranslation("main.tag.change") + "§f" + " (" + alignment.getRequestName() + ")");
                     });
 
                     LabyHelp.this.getConfig().addProperty("rightTag", alignment.name());
@@ -732,7 +731,7 @@ public class LabyHelp extends net.labymod.api.LabyModAddon {
                 }
             } else {
                 if (!getSettingsManager().rightTag.equals(alignment.name())) {
-                    labyPlayer.sendDefaultMessage(EnumChatFormatting.RED + LabyHelp.getInstance().getTranslationManager().getTranslation("main.tag.noperms") + EnumChatFormatting.WHITE + " (" + alignment.getRequestName() + ")");
+                    labyPlayer.sendDefaultMessage("§c" + LabyHelp.getInstance().getTranslationManager().getTranslation("main.tag.noperms") + "§f" + " (" + alignment.getRequestName() + ")");
                 }
             }
 

--- a/src/main/java/de/labyhelp/addon/LabyPlayer.java
+++ b/src/main/java/de/labyhelp/addon/LabyPlayer.java
@@ -2,7 +2,6 @@ package de.labyhelp.addon;
 
 import de.labyhelp.addon.enums.SocialMediaType;
 import net.labymod.main.LabyMod;
-import net.minecraft.util.EnumChatFormatting;
 
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
@@ -18,8 +17,8 @@ public class LabyPlayer {
         this.uuid = uuid;
     }
 
-    public static final String prefix = EnumChatFormatting.DARK_GRAY + "[" + EnumChatFormatting.YELLOW + "Helper" + EnumChatFormatting.DARK_GRAY + "]" + EnumChatFormatting.WHITE;
-    public final String developerPrefix = EnumChatFormatting.DARK_GRAY + "[" + EnumChatFormatting.YELLOW + "Dev-Helper" + EnumChatFormatting.DARK_GRAY + "]" + EnumChatFormatting.GRAY;
+    public static final String prefix = "§8[" + "§e" + "Helper" + "§8" + "]" + "§f";
+    public final String developerPrefix = "§8" + "[" + "§e" + "Dev-Helper" + "§8" + "]" + "§8";
 
 
     public String getSocialMedia(SocialMediaType socialMedia) {
@@ -57,19 +56,19 @@ public class LabyPlayer {
         clipboard.setContents(stringSelection, null);
 
         if (name != null && !name.equals("")) {
-            sendDefaultMessage(LabyHelp.getInstance().getTranslationManager().getTranslation("social.server") + " " + EnumChatFormatting.RED + name + EnumChatFormatting.GRAY + LabyHelp.getInstance().getTranslationManager().getTranslation("main.clipboard"));
+            sendDefaultMessage(LabyHelp.getInstance().getTranslationManager().getTranslation("social.server") + " " + "§c" + name + "§7" + LabyHelp.getInstance().getTranslationManager().getTranslation("main.clipboard"));
 
             LabyMod.getInstance().getLabyModAPI().connectToServer(name);
         } else {
-            LabyHelp.getInstance().sendDefaultMessage(EnumChatFormatting.RED + "No Server found! Error 404");
+            LabyHelp.getInstance().sendDefaultMessage("§c" + "No Server found! Error 404");
         }
     }
 
 
     public void sendAdversting(boolean tip) {
         sendTranslMessage("main.adversting");
-        sendDefaultMessage(EnumChatFormatting.YELLOW + "LabyHelp Teamspeak:" + EnumChatFormatting.BOLD + " https://labyhelp.de/teamspeak");
-        sendDefaultMessage(EnumChatFormatting.YELLOW + "LabyHelp Discord:" + EnumChatFormatting.BOLD + " https://labyhelp.de/discord");
+        sendDefaultMessage("§e" + "LabyHelp Teamspeak:" + "§l" + " https://labyhelp.de/teamspeak");
+        sendDefaultMessage("§e" + "LabyHelp Discord:" + "§l" + " https://labyhelp.de/discord");
 
         if (tip) {
             sendTranslMessage("adversting.turnoff");
@@ -164,20 +163,20 @@ public class LabyPlayer {
 
     public void sendAlertTranslMessage(String key) {
         if (LabyHelp.getInstance().getSettingsManager().onServer) {
-            LabyMod.getInstance().displayMessageInChat(prefix + EnumChatFormatting.RED + " " + LabyHelp.getInstance().getTranslationManager().getTranslation(key));
+            LabyMod.getInstance().displayMessageInChat(prefix + "§c" + " " + LabyHelp.getInstance().getTranslationManager().getTranslation(key));
         }
     }
 
     public void sendWarningTranslMessage(String key) {
         if (LabyHelp.getInstance().getSettingsManager().onServer) {
-            LabyMod.getInstance().displayMessageInChat(prefix + EnumChatFormatting.YELLOW + " " + LabyHelp.getInstance().getTranslationManager().getTranslation(key));
+            LabyMod.getInstance().displayMessageInChat(prefix + "§e" + " " + LabyHelp.getInstance().getTranslationManager().getTranslation(key));
         }
     }
 
 
     public void sendSuccessTranslMessage(String key) {
         if (LabyHelp.getInstance().getSettingsManager().onServer) {
-            LabyMod.getInstance().displayMessageInChat(prefix + EnumChatFormatting.GREEN + " " + LabyHelp.getInstance().getTranslationManager().getTranslation(key));
+            LabyMod.getInstance().displayMessageInChat(prefix + "§a" + " " + LabyHelp.getInstance().getTranslationManager().getTranslation(key));
         }
     }
 

--- a/src/main/java/de/labyhelp/addon/commands/addon/LabyHelpAddonsCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/addon/LabyHelpAddonsCMD.java
@@ -3,7 +3,7 @@ package de.labyhelp.addon.commands.addon;
 import de.labyhelp.addon.LabyHelp;
 import de.labyhelp.addon.LabyPlayer;
 import de.labyhelp.addon.util.commands.HelpCommand;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.Map;
 
@@ -18,10 +18,10 @@ public class LabyHelpAddonsCMD implements HelpCommand {
         LabyHelp.getInstance().getExecutor().submit(() -> {
 
             LabyHelp.getInstance().getStoreHandler().readHelpAddons();
-            labyPlayer.sendDefaultMessage(EnumChatFormatting.BLUE + "LabyHelp Addons:");
+            labyPlayer.sendDefaultMessage("§9" + "LabyHelp Addons:");
             for (Map.Entry<String, String> addons : LabyHelp.getInstance().getStoreHandler().getAddonsList().entrySet()) {
 
-                labyPlayer.sendDefaultMessage(EnumChatFormatting.BOLD + addons.getKey() +  EnumChatFormatting.GRAY + " " + LabyHelp.getInstance().getTranslationManager().getTranslation("main.from") + " " + EnumChatFormatting.BOLD + LabyHelp.getInstance().getStoreHandler().getAddonAuthor(addons.getKey()));
+                labyPlayer.sendDefaultMessage("§l" + addons.getKey() +  "§7" + " " + LabyHelp.getInstance().getTranslationManager().getTranslation("main.from") + " " + "§l" + LabyHelp.getInstance().getStoreHandler().getAddonAuthor(addons.getKey()));
             }
         });
     }

--- a/src/main/java/de/labyhelp/addon/commands/addon/LabyHelpBadgeCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/addon/LabyHelpBadgeCMD.java
@@ -3,7 +3,7 @@ package de.labyhelp.addon.commands.addon;
 import de.labyhelp.addon.LabyPlayer;
 import de.labyhelp.addon.enums.Tags;
 import de.labyhelp.addon.util.commands.HelpCommand;
-import net.minecraft.util.EnumChatFormatting;
+
 
 public class LabyHelpBadgeCMD implements HelpCommand {
     @Override
@@ -20,7 +20,7 @@ public class LabyHelpBadgeCMD implements HelpCommand {
             if (!tags.equals(Tags.NOTHING)) {
                 if (tags.getArray().contains(labyPlayer.getUuid())) {
                     i++;
-                    labyPlayer.sendDefaultMessage(EnumChatFormatting.GREEN + "- " + tags.getRequestName());
+                    labyPlayer.sendDefaultMessage("§a" + "- " + tags.getRequestName());
                 }
             }
         }

--- a/src/main/java/de/labyhelp/addon/commands/addon/LabyHelpCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/addon/LabyHelpCMD.java
@@ -5,7 +5,6 @@ import de.labyhelp.addon.LabyPlayer;
 import de.labyhelp.addon.util.TranslationManager;
 import de.labyhelp.addon.util.commands.HelpCommand;
 import de.labyhelp.addon.util.settings.SettingsManager;
-import net.minecraft.util.EnumChatFormatting;
 
 public class LabyHelpCMD implements HelpCommand {
 
@@ -24,20 +23,20 @@ public class LabyHelpCMD implements HelpCommand {
                 String newestVersion = LabyHelp.getInstance().getVersionHandler().checkNewestLabyHelpVersion();
 
                 if (!LabyHelp.getInstance().getSettingsManager().isNewerVersion) {
-                    labyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + transManager.getTranslation("info.you") + " " + SettingsManager.currentVersion + transManager.getTranslation("new"));
+                    labyPlayer.sendDefaultMessage("§f" + transManager.getTranslation("info.you") + " " + SettingsManager.currentVersion + transManager.getTranslation("new"));
                 }
                 if (LabyHelp.getInstance().getSettingsManager().isNewerVersion) {
-                    labyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + transManager.getTranslation("info.you") + " " + SettingsManager.currentVersion + transManager.getTranslation("old"));
-                    labyPlayer.sendDefaultMessage(EnumChatFormatting.RED + transManager.getTranslation("info.new") + " " + newestVersion);
+                    labyPlayer.sendDefaultMessage("§f" + transManager.getTranslation("info.you") + " " + SettingsManager.currentVersion + transManager.getTranslation("old"));
+                    labyPlayer.sendDefaultMessage("§c" + transManager.getTranslation("info.new") + " " + newestVersion);
                     labyPlayer.sendAlertTranslMessage("info.restart");
                 }
 
                 LabyHelp.getInstance().getVersionHandler().sendNewFeaturesMessage();
             });
         } catch (Exception ignored) {
-            labyPlayer.sendDefaultMessage(EnumChatFormatting.RED + transManager.getTranslation("info.responding") + EnumChatFormatting.BOLD + "909");
+            labyPlayer.sendDefaultMessage("§c" + transManager.getTranslation("info.responding") + "§l" + "909");
         }
-        labyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + "Teamspeak: https://labyhelp.de/teamspeak");
-        labyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + "Discord: https://labyhelp.de/discord");
+        labyPlayer.sendDefaultMessage("§f" + "Teamspeak: https://labyhelp.de/teamspeak");
+        labyPlayer.sendDefaultMessage("§f" + "Discord: https://labyhelp.de/discord");
     }
 }

--- a/src/main/java/de/labyhelp/addon/commands/addon/LabyHelpPartnerCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/addon/LabyHelpPartnerCMD.java
@@ -3,7 +3,6 @@ package de.labyhelp.addon.commands.addon;
 import de.labyhelp.addon.LabyHelp;
 import de.labyhelp.addon.LabyPlayer;
 import de.labyhelp.addon.util.commands.HelpCommand;
-import net.minecraft.util.EnumChatFormatting;
 
 import java.util.Map;
 
@@ -24,9 +23,9 @@ public class LabyHelpPartnerCMD implements HelpCommand {
         } else if (args.length == 1) {
             labyPlayer.sendTranslMessage("main.partner.list");
             for (Map.Entry<String, String> partnerList : LabyHelp.getInstance().getPartnerHandler().getPartner().entrySet()) {
-                labyPlayer.sendDefaultMessage(EnumChatFormatting.GOLD + partnerList.getKey() + EnumChatFormatting.WHITE + " - /lhpartner " + partnerList.getKey());
+                labyPlayer.sendDefaultMessage("§6" + partnerList.getKey() + "§f" + " - /lhpartner " + partnerList.getKey());
             }
-            labyPlayer.sendDefaultMessage(LabyHelp.getInstance().getTranslationManager().getTranslation("main.moreat") + EnumChatFormatting.GOLD + " https://labyhelp.de/partner");
+            labyPlayer.sendDefaultMessage(LabyHelp.getInstance().getTranslationManager().getTranslation("main.moreat") + "§6" + " https://labyhelp.de/partner");
         } else {
             labyPlayer.sendDefaultMessage("/lhpartner || /lhpartner <Server>");
         }

--- a/src/main/java/de/labyhelp/addon/commands/addon/LabyHelpTeamCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/addon/LabyHelpTeamCMD.java
@@ -5,7 +5,7 @@ import de.labyhelp.addon.LabyPlayer;
 import de.labyhelp.addon.enums.HelpGroups;
 import de.labyhelp.addon.util.commands.HelpCommand;
 import net.labymod.utils.UUIDFetcher;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.time.LocalDate;
 import java.util.Map;
@@ -19,10 +19,10 @@ public class LabyHelpTeamCMD implements HelpCommand {
 
     @Override
     public void execute(LabyPlayer clientLabyPlayer, String[] args) {
-        clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.RED + "LabyHelp Team:");
-        clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.RED + "Position: " + LocalDate.now());
-        clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + "Addon Adminstration");
-        clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.YELLOW + "" + EnumChatFormatting.BOLD + "- marvhuel");
+        clientLabyPlayer.sendDefaultMessage("§c" + "LabyHelp Team:");
+        clientLabyPlayer.sendDefaultMessage("§c" + "Position: " + LocalDate.now());
+        clientLabyPlayer.sendDefaultMessage("§f" + "Addon Adminstration");
+        clientLabyPlayer.sendDefaultMessage("§e" + "" + "§l" + "- marvhuel");
         LabyHelp.getInstance().getExecutor().submit(new Runnable() {
             @Override
             public void run() {
@@ -30,39 +30,39 @@ public class LabyHelpTeamCMD implements HelpCommand {
                     if (LabyHelp.getInstance().getGroupManager().isTeam(groupsEntry.getKey())) {
                         if (LabyHelp.getInstance().getGroupManager().getRanked(groupsEntry.getKey()).equals(HelpGroups.ADMIN) || LabyHelp.getInstance().getGroupManager().getRanked(groupsEntry.getKey()).equals(HelpGroups.OWNER)) {
                             if (!groupsEntry.getKey().toString().equals("d4389488-2692-436b-bc10-fce879f7441d")) {
-                                clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.YELLOW + "- " + UUIDFetcher.getName(groupsEntry.getKey()));
+                                clientLabyPlayer.sendDefaultMessage("§e" + "- " + UUIDFetcher.getName(groupsEntry.getKey()));
                             }
                         }
                     }
                 }
-                clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + "Addon Developers");
+                clientLabyPlayer.sendDefaultMessage("§f" + "Addon Developers");
                 for (Map.Entry<UUID, HelpGroups> groupsEntry : LabyHelp.getInstance().getGroupManager().userGroups.entrySet()) {
                     if (LabyHelp.getInstance().getGroupManager().isTeam(groupsEntry.getKey())) {
                         if (LabyHelp.getInstance().getGroupManager().getRanked(groupsEntry.getKey()).equals(HelpGroups.DEVELOPER) || LabyHelp.getInstance().getGroupManager().getRanked(groupsEntry.getKey()).equals(HelpGroups.SRDEVELOPER)) {
-                            clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.YELLOW + "- " + UUIDFetcher.getName(groupsEntry.getKey()));
+                            clientLabyPlayer.sendDefaultMessage("§e" + "- " + UUIDFetcher.getName(groupsEntry.getKey()));
                         }
                     }
                 }
-                clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + "Addon Moderation");
+                clientLabyPlayer.sendDefaultMessage("§f" + "Addon Moderation");
                 for (Map.Entry<UUID, HelpGroups> groupsEntry : LabyHelp.getInstance().getGroupManager().userGroups.entrySet()) {
                     if (LabyHelp.getInstance().getGroupManager().isTeam(groupsEntry.getKey())) {
                         if (LabyHelp.getInstance().getGroupManager().getRanked(groupsEntry.getKey()).equals(HelpGroups.MODERATOR) || LabyHelp.getInstance().getGroupManager().getRanked(groupsEntry.getKey()).equals(HelpGroups.SRMODERATOR)) {
-                            clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.YELLOW + "- " + UUIDFetcher.getName(groupsEntry.getKey()));
+                            clientLabyPlayer.sendDefaultMessage("§e" + "- " + UUIDFetcher.getName(groupsEntry.getKey()));
                         }
                     }
                 }
-                clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + "Addon Contents");
+                clientLabyPlayer.sendDefaultMessage("§f" + "Addon Contents");
                 for (Map.Entry<UUID, HelpGroups> groupsEntry : LabyHelp.getInstance().getGroupManager().userGroups.entrySet()) {
                     if (LabyHelp.getInstance().getGroupManager().isTeam(groupsEntry.getKey())) {
                         if (LabyHelp.getInstance().getGroupManager().getRanked(groupsEntry.getKey()).equals(HelpGroups.CONTENT) || LabyHelp.getInstance().getGroupManager().getRanked(groupsEntry.getKey()).equals(HelpGroups.SRCONTENT)) {
-                            clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.YELLOW + "- " + UUIDFetcher.getName(groupsEntry.getKey()));
+                            clientLabyPlayer.sendDefaultMessage("§e" + "- " + UUIDFetcher.getName(groupsEntry.getKey()));
                         }
                     }
                 }
-                clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + "Addon Supporter");
+                clientLabyPlayer.sendDefaultMessage("§f" + "Addon Supporter");
                 for (Map.Entry<UUID, HelpGroups> groupsEntry : LabyHelp.getInstance().getGroupManager().userGroups.entrySet()) {
                         if (LabyHelp.getInstance().getGroupManager().getRanked(groupsEntry.getKey()).equals(HelpGroups.SUPPORTER)) {
-                            clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.YELLOW + "- " + UUIDFetcher.getName(groupsEntry.getKey()));
+                            clientLabyPlayer.sendDefaultMessage("§e" + "- " + UUIDFetcher.getName(groupsEntry.getKey()));
                         }
                 }
               }

--- a/src/main/java/de/labyhelp/addon/commands/feature/InviteListCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/feature/InviteListCMD.java
@@ -4,7 +4,7 @@ import de.labyhelp.addon.LabyHelp;
 import de.labyhelp.addon.LabyPlayer;
 import de.labyhelp.addon.util.commands.HelpCommand;
 import net.labymod.utils.UUIDFetcher;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.List;
 import java.util.Map;
@@ -22,7 +22,7 @@ public class InviteListCMD implements HelpCommand {
             List<Map.Entry<String, Integer>> list = LabyHelp.getInstance().getInviteManager().getTops5();
             int i = 1;
             for (Map.Entry<String, Integer> uuidStringEntry : list) {
-                labyPlayer.sendDefaultMessage(EnumChatFormatting.YELLOW + "" + i + EnumChatFormatting.WHITE + ": " + EnumChatFormatting.YELLOW + EnumChatFormatting.BOLD + UUIDFetcher.getName(UUID.fromString(uuidStringEntry.getKey())).toUpperCase() + EnumChatFormatting.WHITE + " with " + EnumChatFormatting.YELLOW + EnumChatFormatting.BOLD + uuidStringEntry.getValue() + EnumChatFormatting.WHITE + LabyHelp.getInstance().getTranslationManager().getTranslation("invite.points"));
+                labyPlayer.sendDefaultMessage("§e" + "" + i + "§f" + ": " + "§e" + "§l" + UUIDFetcher.getName(UUID.fromString(uuidStringEntry.getKey())).toUpperCase() + "§f" + " with " + "§e" + "§l" + uuidStringEntry.getValue() + "§f" + LabyHelp.getInstance().getTranslationManager().getTranslation("invite.points"));
                 i++;
             }
         });

--- a/src/main/java/de/labyhelp/addon/commands/feature/InvitesCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/feature/InvitesCMD.java
@@ -5,7 +5,7 @@ import de.labyhelp.addon.LabyPlayer;
 import de.labyhelp.addon.util.TranslationManager;
 import de.labyhelp.addon.util.commands.HelpCommand;
 import net.labymod.utils.UUIDFetcher;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.UUID;
 
@@ -25,9 +25,9 @@ public class InvitesCMD implements HelpCommand {
 
                 if (LabyHelp.getInstance().getGroupManager().userGroups.containsKey(uuid)) {
                     if (LabyHelp.getInstance().getInviteManager().getNowInvites().equalsIgnoreCase("1")) {
-                        labyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + args[1].toUpperCase() +  transManager.getTranslation("likes.has.only") + LabyHelp.getInstance().getInviteManager().getInvites(uuid) + transManager.getTranslation("invite.points") + "!");
+                        labyPlayer.sendDefaultMessage("§f" + args[1].toUpperCase() +  transManager.getTranslation("likes.has.only") + LabyHelp.getInstance().getInviteManager().getInvites(uuid) + transManager.getTranslation("invite.points") + "!");
                     } else {
-                        labyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + args[1].toUpperCase() + transManager.getTranslation("likes.has")  + LabyHelp.getInstance().getInviteManager().getInvites(uuid) + transManager.getTranslation("invite.points") +"!");
+                        labyPlayer.sendDefaultMessage("§f" + args[1].toUpperCase() + transManager.getTranslation("likes.has")  + LabyHelp.getInstance().getInviteManager().getInvites(uuid) + transManager.getTranslation("invite.points") +"!");
                     }
                 } else {
                     labyPlayer.sendTranslMessage("main.hasnot");

--- a/src/main/java/de/labyhelp/addon/commands/feature/LabyHelpLikeCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/feature/LabyHelpLikeCMD.java
@@ -6,7 +6,7 @@ import de.labyhelp.addon.util.TranslationManager;
 import de.labyhelp.addon.util.commands.HelpCommand;
 import net.labymod.main.LabyMod;
 import net.labymod.utils.UUIDFetcher;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.UUID;
 
@@ -33,11 +33,11 @@ public class LabyHelpLikeCMD implements HelpCommand {
 
                                     LabyHelp.getInstance().getLikeManager().readUserLikes();
 
-                                    clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + transManager.getTranslation("likes.like") + EnumChatFormatting.DARK_RED + args[1].toUpperCase() + EnumChatFormatting.RED + "!");
+                                    clientLabyPlayer.sendDefaultMessage("§f" + transManager.getTranslation("likes.like") + "§4" + args[1].toUpperCase() + "§c" + "!");
                                     if (LabyHelp.getInstance().getLikeManager().getLikes(uuid).equalsIgnoreCase("1")) {
-                                        clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + args[1].toUpperCase() + transManager.getTranslation("likes.has.only") + LabyHelp.getInstance().getLikeManager().getLikes(uuid) + " Like!");
+                                        clientLabyPlayer.sendDefaultMessage("§f" + args[1].toUpperCase() + transManager.getTranslation("likes.has.only") + LabyHelp.getInstance().getLikeManager().getLikes(uuid) + " Like!");
                                     } else {
-                                        clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + args[1].toUpperCase() + transManager.getTranslation("likes.has") + LabyHelp.getInstance().getLikeManager().getLikes(uuid) + " Likes!");
+                                        clientLabyPlayer.sendDefaultMessage("§f" + args[1].toUpperCase() + transManager.getTranslation("likes.has") + LabyHelp.getInstance().getLikeManager().getLikes(uuid) + " Likes!");
                                     }
 
                                 });
@@ -51,7 +51,7 @@ public class LabyHelpLikeCMD implements HelpCommand {
                         clientLabyPlayer.sendTranslMessage("main.not.exist");
                     }
                 } else {
-                    clientLabyPlayer.sendDefaultMessage(transManager.getTranslation("likes.already") + EnumChatFormatting.WHITE + args[1]);
+                    clientLabyPlayer.sendDefaultMessage(transManager.getTranslation("likes.already") + "§f" + args[1]);
                 }
             } else {
                 clientLabyPlayer.sendTranslMessage("likes.self");

--- a/src/main/java/de/labyhelp/addon/commands/feature/LikeListCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/feature/LikeListCMD.java
@@ -4,7 +4,7 @@ import de.labyhelp.addon.LabyHelp;
 import de.labyhelp.addon.LabyPlayer;
 import de.labyhelp.addon.util.commands.HelpCommand;
 import net.labymod.utils.UUIDFetcher;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.List;
 import java.util.Map;
@@ -24,7 +24,7 @@ public class LikeListCMD implements HelpCommand {
             int i = 1;
 
             for (Map.Entry<String, Integer> uuidStringEntry : list) {
-                labyPlayer.sendDefaultMessage(EnumChatFormatting.YELLOW + "" + i + EnumChatFormatting.WHITE + ": " + EnumChatFormatting.YELLOW + EnumChatFormatting.BOLD + UUIDFetcher.getName(UUID.fromString(uuidStringEntry.getKey())).toUpperCase() + EnumChatFormatting.WHITE + " with " + EnumChatFormatting.YELLOW + EnumChatFormatting.BOLD + uuidStringEntry.getValue() + EnumChatFormatting.WHITE + " Likes");
+                labyPlayer.sendDefaultMessage("§e" + "" + i + "§f" + ": " + "§e" + "§l" + UUIDFetcher.getName(UUID.fromString(uuidStringEntry.getKey())).toUpperCase() + "§f" + " with " + "§e" + "§l" + uuidStringEntry.getValue() + "§f" + " Likes");
                 i++;
             }
         });

--- a/src/main/java/de/labyhelp/addon/commands/feature/LikesCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/feature/LikesCMD.java
@@ -5,7 +5,7 @@ import de.labyhelp.addon.LabyPlayer;
 import de.labyhelp.addon.util.TranslationManager;
 import de.labyhelp.addon.util.commands.HelpCommand;
 import net.labymod.utils.UUIDFetcher;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.UUID;
 
@@ -25,9 +25,9 @@ public class LikesCMD implements HelpCommand {
 
                 if (LabyHelp.getInstance().getGroupManager().userGroups.containsKey(uuid)) {
                     if (LabyHelp.getInstance().getLikeManager().getLikes(uuid).equalsIgnoreCase("1")) {
-                        clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + args[1].toUpperCase()+  transManager.getTranslation("likes.has.only") +LabyHelp.getInstance().getLikeManager().getLikes(uuid) + " Like!");
+                        clientLabyPlayer.sendDefaultMessage("§f" + args[1].toUpperCase()+  transManager.getTranslation("likes.has.only") +LabyHelp.getInstance().getLikeManager().getLikes(uuid) + " Like!");
                     } else {
-                        clientLabyPlayer.sendDefaultMessage(EnumChatFormatting.WHITE + args[1].toUpperCase() +  transManager.getTranslation("likes.has") + LabyHelp.getInstance().getLikeManager().getLikes(uuid) + " Likes!");
+                        clientLabyPlayer.sendDefaultMessage("§f" + args[1].toUpperCase() +  transManager.getTranslation("likes.has") + LabyHelp.getInstance().getLikeManager().getLikes(uuid) + " Likes!");
                     }
                 } else {
                     clientLabyPlayer.sendTranslMessage("main.hasnot");

--- a/src/main/java/de/labyhelp/addon/commands/feature/TargetCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/feature/TargetCMD.java
@@ -6,7 +6,7 @@ import de.labyhelp.addon.enums.HelpGroups;
 import de.labyhelp.addon.util.commands.HelpCommand;
 import net.labymod.main.LabyMod;
 import net.labymod.utils.UUIDFetcher;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.Map;
 import java.util.UUID;
@@ -25,7 +25,7 @@ public class TargetCMD implements HelpCommand {
 
                 if (!LabyHelp.getInstance().getSettingsManager().targetPlayers.isEmpty()) {
                     for (Map.Entry<UUID, Integer> targetPlayer : LabyHelp.getInstance().getSettingsManager().getTargetPlayers().entrySet()) {
-                        labyPlayer.sendDefaultMessage(EnumChatFormatting.YELLOW + "-" + UUIDFetcher.getName(targetPlayer.getKey()) + ", " + targetPlayer.getValue() + " " + LabyHelp.getInstance().getTranslationManager().getTranslation("main.target.big"));
+                        labyPlayer.sendDefaultMessage("§e" + "-" + UUIDFetcher.getName(targetPlayer.getKey()) + ", " + targetPlayer.getValue() + " " + LabyHelp.getInstance().getTranslationManager().getTranslation("main.target.big"));
                     }
                 } else {
                     labyPlayer.sendAlertTranslMessage("main.target.null");

--- a/src/main/java/de/labyhelp/addon/commands/team/LabyHelpBanCMD.java
+++ b/src/main/java/de/labyhelp/addon/commands/team/LabyHelpBanCMD.java
@@ -7,7 +7,7 @@ import de.labyhelp.addon.util.TranslationManager;
 import de.labyhelp.addon.util.commands.HelpCommand;
 import net.labymod.main.LabyMod;
 import net.labymod.utils.UUIDFetcher;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.UUID;
 
@@ -25,7 +25,7 @@ public class LabyHelpBanCMD implements HelpCommand {
                 final UUID uuid = UUIDFetcher.getUUID(args[1]);
                 if (!LabyHelp.getInstance().getGroupManager().isTeam(uuid)) {
                     if (uuid != null) {
-                        clientLabyPlayer.sendDefaultMessage(transManager.getTranslation("player") + " " + EnumChatFormatting.WHITE + args[1] + "" + EnumChatFormatting.WHITE + transManager.getTranslation("staff.banned.nametag"));
+                        clientLabyPlayer.sendDefaultMessage(transManager.getTranslation("player") + " " + "§f" + args[1] + "" + "§f" + transManager.getTranslation("staff.banned.nametag"));
                         sendBanned(uuid);
                     } else {
                         clientLabyPlayer.sendTranslMessage("main.not.exist");

--- a/src/main/java/de/labyhelp/addon/enums/HelpGroups.java
+++ b/src/main/java/de/labyhelp/addon/enums/HelpGroups.java
@@ -1,48 +1,48 @@
 package de.labyhelp.addon.enums;
 
 import de.labyhelp.addon.LabyHelp;
-import net.minecraft.util.EnumChatFormatting;
+
 
 public enum HelpGroups {
 
-    USER("USER", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.GRAY + " ", false, false,false, false, "rank.user"),
+    USER("USER", "§f" + "" + "§l" + "LabyHelp" + "§7" + " ", false, false,false, false, "rank.user"),
 
-    BANNED("BANNED", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.GRAY + " ", false, false, false, false, "rank.user"),
-    TARGET("TARGET", EnumChatFormatting.DARK_RED + "" + EnumChatFormatting.BOLD + " ", false, false, false, false, "rank.target"),
+    BANNED("BANNED", "§f" + "" + "§l" + "LabyHelp" + "§7" + " ", false, false, false, false, "rank.user"),
+    TARGET("TARGET", "§4" + "" + "§l" + " ", false, false, false, false, "rank.target"),
 
-    FAME("FAME", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.YELLOW + " FAME", true, false, false, false, null),
-    FAMOUS("FAMOUS", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.YELLOW + EnumChatFormatting.BOLD + " FAMOUS", false, true, false, false, null),
-    INVITER("INVITER", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.AQUA + " ", true, false, false, false, "rank.inviter"),
+    FAME("FAME", "§f" + "" + "§l" + "LabyHelp" + "§e" + " FAME", true, false, false, false, null),
+    FAMOUS("FAMOUS", "§f" + "" + "§l" + "LabyHelp" + "§e" + "§l" + " FAMOUS", false, true, false, false, null),
+    INVITER("INVITER", "§f" + "" + "§l" + "LabyHelp" + "§3" + " ", true, false, false, false, "rank.inviter"),
 
-    BOOSTER("BOOSTER", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.LIGHT_PURPLE + "" + EnumChatFormatting.BOLD + " ", false, true, false, false, "rank.booster"),
+    BOOSTER("BOOSTER", "§f" + "" + "§l" + "LabyHelp" + "§d" + "" + "§l" + " ", false, true, false, false, "rank.booster"),
 
-    PREMIUM("PREMIUM", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.DARK_AQUA + " Premium", true, true, false, false, null),
-    DONATOR("DONATOR", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.YELLOW + "" + EnumChatFormatting.BOLD + " DONATOR", true, true, false, false,null),
-    FRIEND("FRIEND", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.GOLD + " ", true, true,false, true, "rank.friend"),
-    PREMIUM_("PREMIUM_", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.YELLOW + "" + EnumChatFormatting.BOLD + " PREMIUM+", true, true, false, false,null),
+    PREMIUM("PREMIUM", "§f" + "" + "§l" + "LabyHelp" + "§3" + " Premium", true, true, false, false, null),
+    DONATOR("DONATOR", "§f" + "" + "§l" + "LabyHelp" + "§e" + "" + "§l" + " DONATOR", true, true, false, false,null),
+    FRIEND("FRIEND", "§f" + "" + "§l" + "LabyHelp" + "§6" + " ", true, true,false, true, "rank.friend"),
+    PREMIUM_("PREMIUM_", "§f" + "" + "§l" + "LabyHelp" + "§e" + "" + "§l" + " PREMIUM+", true, true, false, false,null),
 
-    CREATOR("CREATOR", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.DARK_PURPLE + EnumChatFormatting.BOLD + " ", true, true,false, true, "rank.creator"),
-    PARTNER("PARTNER", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.DARK_PURPLE + EnumChatFormatting.BOLD + " ", true, true,false, true, "rank.partner"),
+    CREATOR("CREATOR", "§f" + "" + "§l" + "LabyHelp" + "§5" + "§l" + " ", true, true,false, true, "rank.creator"),
+    PARTNER("PARTNER", "§f" + "" + "§l" + "LabyHelp" + "§5" + "§l" + " ", true, true,false, true, "rank.partner"),
 
-    TRANSLATOR("TRANSLATOR", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.LIGHT_PURPLE + " CONTENT", true, true,false, true, null),
+    TRANSLATOR("TRANSLATOR", "§f" + "" + "§l" + "LabyHelp" + "§d" + " CONTENT", true, true,false, true, null),
 
-    JRCONTENT("JRCONTENT", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.LIGHT_PURPLE + " CONTENT", true, true,false, true, null),
-    CONTENT("CONTENT", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.LIGHT_PURPLE + " CONTENT", true, true,true, true, null),
+    JRCONTENT("JRCONTENT", "§f" + "" + "§l" + "LabyHelp" + "§d" + " CONTENT", true, true,false, true, null),
+    CONTENT("CONTENT", "§f" + "" + "§l" + "LabyHelp" + "§d" + " CONTENT", true, true,true, true, null),
 
-    SRCONTENT("SRCONTENT", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.LIGHT_PURPLE + EnumChatFormatting.BOLD + " SRCONTENT", true,true, true, true, null),
+    SRCONTENT("SRCONTENT", "§f" + "" + "§l" + "LabyHelp" + "§d" + "§l" + " SRCONTENT", true,true, true, true, null),
 
-    JRSUPPORTER("JRSUPPORTER", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.RED + " SUPPORTER", true, true,false, true, null),
-    SUPPORTER("SUPPORTER", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.RED + " SUPPORTER", true, true,false, true, null),
+    JRSUPPORTER("JRSUPPORTER", "§f" + "" + "§l" + "LabyHelp" + "§c" + " SUPPORTER", true, true,false, true, null),
+    SUPPORTER("SUPPORTER", "§f" + "" + "§l" + "LabyHelp" + "§c" + " SUPPORTER", true, true,false, true, null),
 
-    JRMODERATOR("JRMODERATOR", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.RED + " JRMODERATOR", true, true,false, true, null),
-    MODERATOR("MODERATOR", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.RED + " MODERATOR", true, true,true, true, null),
-    SRMODERATOR("SRMODERATOR", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.RED + EnumChatFormatting.BOLD + " SRMODERATOR", true,true, true, true, null),
+    JRMODERATOR("JRMODERATOR", "§f" + "" + "§l" + "LabyHelp" + "§c" + " JRMODERATOR", true, true,false, true, null),
+    MODERATOR("MODERATOR", "§f" + "" + "§l" + "LabyHelp" + "§c" + " MODERATOR", true, true,true, true, null),
+    SRMODERATOR("SRMODERATOR", "§f" + "" + "§l" + "LabyHelp" + "§c" + "§l" + " SRMODERATOR", true,true, true, true, null),
 
-    DEVELOPER("DEVELOPER", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.AQUA + " Developer", true, true,true, true, null),
-    SRDEVELOPER("SRDEVELOPER", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "LabyHelp" + EnumChatFormatting.AQUA + EnumChatFormatting.BOLD + " SRDEVELOPER", true, true,true, true, null),
+    DEVELOPER("DEVELOPER", "§f" + "" + "§l" + "LabyHelp" + "§3" + " Developer", true, true,true, true, null),
+    SRDEVELOPER("SRDEVELOPER", "§f" + "" + "§l" + "LabyHelp" + "§3" + "§l" + " SRDEVELOPER", true, true,true, true, null),
 
-    ADMIN("ADMIN", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "" + "LabyHelp" + EnumChatFormatting.DARK_RED + EnumChatFormatting.BOLD +" ADMIN", true,true, true, true, null),
-    OWNER("OWNER", EnumChatFormatting.WHITE + "" + EnumChatFormatting.BOLD + "" + "LabyHelp" + EnumChatFormatting.DARK_RED + EnumChatFormatting.BOLD + " ADMIN", true,true, true, true, null);
+    ADMIN("ADMIN", "§f" + "" + "§l" + "" + "LabyHelp" + "§4" + "§l" +" ADMIN", true,true, true, true, null),
+    OWNER("OWNER", "§f" + "" + "§l" + "" + "LabyHelp" + "§4" + "§l" + " ADMIN", true,true, true, true, null);
 
 
     private final String name, prefix;

--- a/src/main/java/de/labyhelp/addon/enums/Tags.java
+++ b/src/main/java/de/labyhelp/addon/enums/Tags.java
@@ -2,7 +2,7 @@ package de.labyhelp.addon.enums;
 
 import de.labyhelp.addon.LabyHelp;
 import lombok.Getter;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -12,13 +12,13 @@ import java.util.UUID;
 public enum Tags {
 
     NOTHING("", false, "Nothing", "none", null, false),
-    DISCORD_NORMAL_TAG(EnumChatFormatting.GRAY + " ✪ ", false, "NORMAL", "tag", LabyHelp.getInstance().getTagManager().normalDiscordTag, true),
+    DISCORD_NORMAL_TAG("§7" + " ✪ ", false, "NORMAL", "tag", LabyHelp.getInstance().getTagManager().normalDiscordTag, true),
     DISCORD_RAINBOW_TAG(" ✪ ", true, "CHROME", "tag", LabyHelp.getInstance().getTagManager().chromeDiscordTag, true),
 
-    PREMIUM_TAG(EnumChatFormatting.GOLD + " Ⓟ ", false, "PREMIUM", "premium", LabyHelp.getInstance().getGroupManager().getAllPremiumPlayers(), false),
+    PREMIUM_TAG("§6" + " Ⓟ ", false, "PREMIUM", "premium", LabyHelp.getInstance().getGroupManager().getAllPremiumPlayers(), false),
 
-    SERVER_TAG(EnumChatFormatting.DARK_AQUA + " Ⓢ ", false, "SERVER", "serverPartner", LabyHelp.getInstance().getTagManager().serverTag, true),
-    EASTER_2021_TAG(EnumChatFormatting.GREEN + " ⚘ ", false, "EASTER2021", "easter", LabyHelp.getInstance().getTagManager().easterDiscordTag, false);
+    SERVER_TAG("§3" + " Ⓢ ", false, "SERVER", "serverPartner", LabyHelp.getInstance().getTagManager().serverTag, true),
+    EASTER_2021_TAG("§a" + " ⚘ ", false, "EASTER2021", "easter", LabyHelp.getInstance().getTagManager().easterDiscordTag, false);
 
     private final String tagDisplayed;
     private final Boolean isRainbow;

--- a/src/main/java/de/labyhelp/addon/listeners/ClientJoinListener.java
+++ b/src/main/java/de/labyhelp/addon/listeners/ClientJoinListener.java
@@ -5,7 +5,7 @@ import net.labymod.main.LabyMod;
 import net.labymod.user.cosmetic.cosmetics.partner.CosmeticStegi;
 import net.labymod.utils.Consumer;
 import net.labymod.utils.ServerData;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.Map;
 

--- a/src/main/java/de/labyhelp/addon/module/DegreeModule.java
+++ b/src/main/java/de/labyhelp/addon/module/DegreeModule.java
@@ -7,20 +7,20 @@ import net.labymod.ingamegui.moduletypes.SimpleModule;
 import net.labymod.settings.elements.ControlElement;
 import net.labymod.utils.Material;
 import net.minecraft.client.Minecraft;
-import net.minecraft.util.EnumChatFormatting;
+
 
 public class DegreeModule extends SimpleModule {
 
     private String getDegree() {
         if (LabyHelp.getInstance().getSettingsManager().onServer) {
             if (Minecraft.getMinecraft().thePlayer.rotationPitch == 90) {
-                return EnumChatFormatting.RED + String.valueOf(Minecraft.getMinecraft().thePlayer.rotationPitch);
+                return "§c" + String.valueOf(Minecraft.getMinecraft().thePlayer.rotationPitch);
             } else if (Minecraft.getMinecraft().thePlayer.rotationPitch == -90) {
-                return EnumChatFormatting.RED + String.valueOf(Minecraft.getMinecraft().thePlayer.rotationPitch);
+                return "§c" + String.valueOf(Minecraft.getMinecraft().thePlayer.rotationPitch);
             } else if (Minecraft.getMinecraft().thePlayer.rotationPitch < 1 && Minecraft.getMinecraft().thePlayer.rotationPitch > -1) {
-                return EnumChatFormatting.GREEN + String.valueOf(Minecraft.getMinecraft().thePlayer.rotationPitch);
+                return "§a" + String.valueOf(Minecraft.getMinecraft().thePlayer.rotationPitch);
             } else if (Minecraft.getMinecraft().thePlayer.rotationPitch < 81 && Minecraft.getMinecraft().thePlayer.rotationPitch > 74) {
-                return EnumChatFormatting.YELLOW + String.valueOf(Minecraft.getMinecraft().thePlayer.rotationPitch);
+                return "§e" + String.valueOf(Minecraft.getMinecraft().thePlayer.rotationPitch);
             } else {
                 return String.valueOf(Minecraft.getMinecraft().thePlayer.rotationPitch);
             }

--- a/src/main/java/de/labyhelp/addon/util/CommunicatorHandler.java
+++ b/src/main/java/de/labyhelp/addon/util/CommunicatorHandler.java
@@ -9,7 +9,7 @@ import de.labyhelp.addon.enums.LabyVersion;
 import de.labyhelp.addon.util.settings.SettingsManager;
 import net.labymod.main.LabyMod;
 import net.minecraft.client.Minecraft;
-import net.minecraft.util.EnumChatFormatting;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -149,22 +149,22 @@ public class CommunicatorHandler {
 
             if (!LabyHelp.getInstance().getGroupManager().getNowRanked().getName().equalsIgnoreCase(LabyHelp.getInstance().getGroupManager().getBeforeRanked().getName())) {
                 if (LabyHelp.getInstance().getGroupManager().getNowRanked().equals(HelpGroups.BANNED)) {
-                    LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + EnumChatFormatting.WHITE + " ---------LabyHelp----------");
-                    LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + EnumChatFormatting.RED + " Your NameTag has been banned for one day");
-                    LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + EnumChatFormatting.YELLOW + translationManager.getTranslation("main.rules") + ": https://labyhelp.de/tag-rules");
-                    LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + EnumChatFormatting.WHITE + " ---------LabyHelp----------");
+                    LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + "§f" + " ---------LabyHelp----------");
+                    LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + "§c" + " Your NameTag has been banned for one day");
+                    LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + "§e" + translationManager.getTranslation("main.rules") + ": https://labyhelp.de/tag-rules");
+                    LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + "§f" + " ---------LabyHelp----------");
 
                 } else {
-                    LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + EnumChatFormatting.GREEN + translationManager.getTranslation("main.rankchange") + " (" + EnumChatFormatting.WHITE + LabyHelp.getInstance().getGroupManager().getNowRanked().getName() + EnumChatFormatting.GREEN + ")");
+                    LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + "§a" + translationManager.getTranslation("main.rankchange") + " (" + "§f" + LabyHelp.getInstance().getGroupManager().getNowRanked().getName() + "§a" + ")");
                 }
             }
 
             if (!LabyHelp.getInstance().getLikeManager().getBeforeLikes().equalsIgnoreCase(LabyHelp.getInstance().getLikeManager().getNowLikes())) {
-                LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + EnumChatFormatting.GREEN + translationManager.getTranslation("main.profilelike") + " (" + EnumChatFormatting.WHITE + LabyHelp.getInstance().getLikeManager().getNowLikes() + EnumChatFormatting.GREEN + ")");
+                LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + "§a" + translationManager.getTranslation("main.profilelike") + " (" + "§f" + LabyHelp.getInstance().getLikeManager().getNowLikes() + "§a" + ")");
             }
 
             if (!LabyHelp.getInstance().getInviteManager().getBeforeInvites().equalsIgnoreCase(LabyHelp.getInstance().getInviteManager().getNowInvites())) {
-                LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + EnumChatFormatting.GREEN + translationManager.getTranslation("main.predeemedcode") + " (" + EnumChatFormatting.WHITE + LabyHelp.getInstance().getInviteManager().getNowInvites() + EnumChatFormatting.GREEN + ")");
+                LabyMod.getInstance().displayMessageInChat(LabyPlayer.prefix + "§a" + translationManager.getTranslation("main.predeemedcode") + " (" + "§f" + LabyHelp.getInstance().getInviteManager().getNowInvites() + "§a" + ")");
             }
 
         }

--- a/src/main/java/de/labyhelp/addon/util/GroupManager.java
+++ b/src/main/java/de/labyhelp/addon/util/GroupManager.java
@@ -3,7 +3,7 @@ package de.labyhelp.addon.util;
 import de.labyhelp.addon.LabyHelp;
 import de.labyhelp.addon.enums.HelpGroups;
 import net.labymod.main.LabyMod;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.*;
 
@@ -15,6 +15,17 @@ public class GroupManager {
     public final Map<UUID, HelpGroups> oldGroups = new HashMap<>();
     public final Map<UUID, String> userNameTags = new HashMap<>();
     public final Map<UUID, String> userSecondNameTags = new HashMap<>();
+
+    private final Random random = new Random();
+    private final String[] colorCodes;
+
+    public GroupManager()
+    {
+        final List<String> colorCodes = new ArrayList<>();
+        for(int i = 0; i < 16; i++)
+            colorCodes.add(Integer.toHexString(i));
+        this.colorCodes = colorCodes.toArray(new String[0]);
+    }
 
     private final ArrayList<UUID> allPremiumPlayers = new ArrayList<>();
 
@@ -89,34 +100,9 @@ public class GroupManager {
         return false;
     }
 
-
-    private EnumChatFormatting chooseColor;
-
-    public EnumChatFormatting randomColor(boolean disco) {
-        return chooseColor(EnumChatFormatting.values()[new Random().nextInt(16)], disco);
-    }
-
-    private EnumChatFormatting chooseColor(EnumChatFormatting color, boolean disco) {
-        if (rainbow) {
-
-            if (disco) {
-                return color;
-            }
-
-            chooseColor = color;
-            rainbow = false;
-
-            return color;
-        } else {
-            if (disco) {
-                return color;
-            } else if (chooseColor != null) {
-                return chooseColor;
-            } else {
-                chooseColor = color;
-                return color;
-
-            }
-        }
+    public String randomColor(boolean disco)
+    {
+        //What is disco supposed to do?
+        return colorCodes[random.nextInt(colorCodes.length)];
     }
 }

--- a/src/main/java/de/labyhelp/addon/util/NameTagManager.java
+++ b/src/main/java/de/labyhelp/addon/util/NameTagManager.java
@@ -5,7 +5,7 @@ import de.labyhelp.addon.enums.HelpGroups;
 import de.labyhelp.addon.enums.NameTags;
 import net.labymod.main.LabyMod;
 import net.labymod.user.User;
-import net.minecraft.util.EnumChatFormatting;
+
 
 import java.util.HashMap;
 import java.util.Map;
@@ -84,9 +84,9 @@ public class NameTagManager {
 
                     if (!getInstance().getGroupManager().isTag(uuidUserEntry.getKey())) {
                         String finishFinalTag = disco.replace("LabyMod", "CENSORED");
-                        LabyMod.getInstance().getUserManager().getUser(uuidUserEntry.getKey()).setSubTitle(EnumChatFormatting.WHITE + finishFinalTag);
+                        LabyMod.getInstance().getUserManager().getUser(uuidUserEntry.getKey()).setSubTitle("§f" + finishFinalTag);
                     } else {
-                        LabyMod.getInstance().getUserManager().getUser(uuidUserEntry.getKey()).setSubTitle(EnumChatFormatting.WHITE + disco);
+                        LabyMod.getInstance().getUserManager().getUser(uuidUserEntry.getKey()).setSubTitle("§f" + disco);
                     }
 
                     if (getInstance().getSettingsManager().nameTagSize != 0) {

--- a/src/main/java/de/labyhelp/addon/util/TagManager.java
+++ b/src/main/java/de/labyhelp/addon/util/TagManager.java
@@ -6,7 +6,7 @@ import de.labyhelp.addon.enums.Tags;
 import de.labyhelp.addon.enums.TagsSide;
 import net.labymod.main.LabyMod;
 import net.labymod.user.group.LabyGroup;
-import net.minecraft.util.EnumChatFormatting;
+
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
@@ -26,7 +26,7 @@ public class TagManager {
     public ArrayList<UUID> serverTag = new ArrayList<>();
     public ArrayList<UUID> chromeDiscordTag = new ArrayList<>();
     public ArrayList<UUID> easterDiscordTag = new ArrayList<>();
-    private EnumChatFormatting colorCache;
+    private String colorCache;
 
     public HashMap<UUID, Tags> rightPlayerList = new HashMap<>();
     public HashMap<UUID, Tags> leftPlayerList = new HashMap<>();

--- a/src/main/java/de/labyhelp/addon/util/VersionHandler.java
+++ b/src/main/java/de/labyhelp/addon/util/VersionHandler.java
@@ -3,7 +3,7 @@ package de.labyhelp.addon.util;
 import de.labyhelp.addon.LabyHelp;
 import de.labyhelp.addon.enums.LabyVersion;
 import de.labyhelp.addon.util.settings.SettingsManager;
-import net.minecraft.util.EnumChatFormatting;
+
 
 public class VersionHandler {
 
@@ -52,7 +52,7 @@ public class VersionHandler {
             if (!LabyHelp.getInstance().getTranslationManager().getTranslation("main.newFeatures").equals("")
                     && !LabyHelp.getInstance().getTranslationManager().getTranslation("main.newFeatures").equals("main.newFeatures")) {
                 if (!LabyHelp.getInstance().getSettingsManager().isNewerVersion) {
-                    LabyHelp.getInstance().sendSpecficTranslMessage(EnumChatFormatting.RED + " " + LabyHelp.getInstance().getTranslationManager().getTranslation("info.new") + ":" + EnumChatFormatting.WHITE, "main.newFeatures");
+                    LabyHelp.getInstance().sendSpecficTranslMessage("§c" + " " + LabyHelp.getInstance().getTranslationManager().getTranslation("info.new") + ":" + "§f", "main.newFeatures");
 
                     LabyHelp.getInstance().getConfig().addProperty("newVersionMessage", false);
                     LabyHelp.getInstance().getSettingsManager().newVersionMessage = false;


### PR DESCRIPTION
I've already created an issue-report. This would be a workaround.
Maybe some colors are broken (e.g. GroupManager.randomColor -> what is that disco boolean...).

It could be possible that other net.minecraft imports are broken as well